### PR TITLE
Add invokeIgnoreResult method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,37 @@ throttledFn(5)
 // foo will be called with 4
 ```
 
+### `throttledFn.invokeIgnoreResult(args)`
+
+Calls the throttled function soon, but doesn't return a promise, catches any CanceledError, and doesn't create any new promises if a call is already pending.
+
+To use this, you should handle all errors inside the throttled function:
+
+```js
+const throttled = throttle(async (arg) => {
+  try {
+    await doSomething(arg)
+  } catch (err) {
+    // handle error
+  }
+})
+```
+
+Then call `invokeIgnoreResult` instead of the throttled function:
+
+```js
+throttled.invokeIgnoreResult(arg)
+```
+
+The `invokeIgnoreResult` method is useful because the following code example would leave 1000 pending promises
+on the heap, even though the catch block is a no-op:
+
+```js
+for (let i = 0; i < 1000; i++) {
+  throttled(arg).catch(() => {})
+}
+```
+
 ### `throttledFn.cancel()`
 
 Cancels the pending invocation, if any. All `Promise`s tracking the pending invocation will be

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ export default function throttle<Args extends any[], Value>(
   }
 ): {
   (...args: Args): Promise<Value>
+  invokeIgnoreResult: (...args: Args) => void
   cancel: () => Promise<void>
   flush: () => Promise<void>
 }

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ function throttle<Args: Array<any>, Value>(
   } = {}
 ): {
   (...args: Args): Promise<Value>,
+  invokeIgnoreResult: (...args: Args) => void,
   cancel: () => Promise<void>,
   flush: () => Promise<void>,
 } {
@@ -84,16 +85,55 @@ function throttle<Args: Array<any>, Value>(
     return result
   }
 
+  function setNextArgs(...args: Args) {
+    nextArgs = nextArgs ? getNextArgs(nextArgs, args) : args
+    if (!nextArgs) throw new Error('unexpected error: nextArgs is null')
+  }
+
+  function doInvoke(): Promise<Value> {
+    return (nextInvocation = (delay || Promise.resolve()).then(invoke))
+  }
   function wrapper(...args: Args): Promise<Value> {
     try {
-      nextArgs = nextArgs ? getNextArgs(nextArgs, args) : args
+      setNextArgs(...args)
     } catch (error) {
       return Promise.reject(error)
     }
-    if (!nextArgs)
-      return Promise.reject(new Error('unexpected error: nextArgs is null'))
-    if (nextInvocation) return nextInvocation
-    return (nextInvocation = (delay || Promise.resolve()).then(invoke))
+    return nextInvocation || doInvoke()
+  }
+
+  /**
+   * Calls the throttled function soon, but doesn't return a promise, catches
+   * any CanceledError, and doesn't create any new promises if a call is already
+   * pending.
+   *
+   * The throttled function should handle all errors internally,
+   * e.g.:
+   *
+   * asyncThrottle(async () => {
+   *   try {
+   *     await foo()
+   *   } catch (err) {
+   *     // handle error
+   *   }
+   * })
+   *
+   * If the throttled function throws an error or returns a promise that is
+   * eventually rejected, the runtime's unhandled promise rejection handler will
+   * be called, which may crash the process, route the rejection to a handler
+   * that has been previously registered, or ignore the rejection, depending
+   * on the runtime and your code.
+   */
+  wrapper.invokeIgnoreResult = (...args: Args) => {
+    setNextArgs(...args)
+    if (!nextInvocation) {
+      doInvoke().catch((err: any) => {
+        if (!(err instanceof CanceledError)) {
+          // trigger the unhandled promise rejection handler
+          throw err
+        }
+      })
+    }
   }
 
   wrapper.cancel = async (): Promise<void> => {
@@ -124,6 +164,7 @@ module.exports = ((throttle: any): {
     }
   ): {
     (...args: Args): Promise<Value>,
+    invokeIgnoreResult: (...args: Args) => void,
     cancel: () => Promise<void>,
     flush: () => Promise<void>,
   },

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ function throttle<Args: Array<any>, Value>(
     return result
   }
 
-  function setNextArgs(...args: Args) {
+  function setNextArgs(args: Args) {
     nextArgs = nextArgs ? getNextArgs(nextArgs, args) : args
     if (!nextArgs) throw new Error('unexpected error: nextArgs is null')
   }
@@ -95,7 +95,7 @@ function throttle<Args: Array<any>, Value>(
   }
   function wrapper(...args: Args): Promise<Value> {
     try {
-      setNextArgs(...args)
+      setNextArgs(args)
     } catch (error) {
       return Promise.reject(error)
     }
@@ -125,7 +125,7 @@ function throttle<Args: Array<any>, Value>(
    * on the runtime and your code.
    */
   wrapper.invokeIgnoreResult = (...args: Args) => {
-    setNextArgs(...args)
+    setNextArgs(args)
     if (!nextInvocation) {
       doInvoke().catch((err: any) => {
         if (!(err instanceof CanceledError)) {

--- a/test/index.js
+++ b/test/index.js
@@ -71,7 +71,7 @@ describe('throttle', () => {
     const fn = throttle(async (x) => x * 2, 100, {
       getNextArgs: () => (null: any),
     })
-    expect(Promise.all([fn(1), fn(1)])).to.be.rejectedWith(
+    await expect(Promise.all([fn(1), fn(1), fn(1), fn(1)])).to.be.rejectedWith(
       'unexpected error: nextArgs is null'
     )
   })


### PR DESCRIPTION
Our usual idiom of:
```
const throttled = asyncThrottle(async () => {
 // ... some code ...
}, interval)
onEvent(() => {
  throttled().catch(() => {})
})
```
can be problematic because if `onEvent` fires 100,000 times between invocations of the wrapped function, there will be 100,000 pending promises on the heap.

The following pattern, with the accompanying change, would create only one pending promise:

```
const throttled = asyncThrottle(async () => {
 // ... some code ...
}, interval)
onEvent(() => {
  throttled.invokeSafe()
})
```
